### PR TITLE
Feat: return only Bitcoin or Lightning documents when a category is specified

### DIFF
--- a/src/lib/curriculumLogic.ts
+++ b/src/lib/curriculumLogic.ts
@@ -23,5 +23,5 @@ export async function getTopics(): Promise<Topic[]> {
 }
 
 export function getTopic(title: string): Topic | undefined {
-    return topics.find(topic => topic.title.includes(title) || topic.slug.includes(title) || topic.aliases?.includes(title));
+    return topics.find(topic => topic.title.includes(title) || topic.slug.toLowerCase().includes(title.toLowerCase()) || topic.aliases?.includes(title));
 }   

--- a/src/pages/api/curriculum.ts
+++ b/src/pages/api/curriculum.ts
@@ -35,6 +35,21 @@ let baseQuery = {
                         "type.keyword": "combined-summary",
                     },
                 },
+                {
+                    "match": {
+                        "title": "Lightning"
+                    }
+                },
+                {
+                    "match": {
+                        "body": "Lightning"
+                    }
+                },
+                {
+                    "match": {
+                        "summary": "Lightning"
+                    }
+                },
             ],
         },
     },


### PR DESCRIPTION
This adds Bitcoin, Lightning Category search, also exclude documents that are replies.